### PR TITLE
Update/ Windows CHeck for python executable

### DIFF
--- a/src/siblink/Config.py
+++ b/src/siblink/Config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import glob
 import click
@@ -157,9 +158,11 @@ class Config(metaclass=ConfigMeta):
 
     if not cls.venv.exists():
       return 0
+    
+    isWindows: bool = sys.platform == "win32"
 
-    cls.python_exe: Path = cls.venv / cls.os_switch / "python.exe"
-    cls.pip_exe: Path = cls.venv / cls.os_switch / "pip.exe"
+    cls.python_exe: Path = cls.venv / cls.os_switch / "python" + ".exe" if isWindows else "" 
+    cls.pip_exe: Path = cls.venv / cls.os_switch / "pip" + ".exe" if isWindows else ""
     cls.package_root = Path(__file__).parent
     return 1
 


### PR DESCRIPTION
Ubuntu doesn't use .exe for the python command.